### PR TITLE
Update code and build for sdk-2018.1

### DIFF
--- a/checksum/dpu/Makefile
+++ b/checksum/dpu/Makefile
@@ -13,7 +13,7 @@ BUILDDIR    := ../obj/dpu
 TARGETDIR   := ../bin/dpu
 SRCEXT      := c
 ASMEXT      := s
-OBJEXT      := ipr
+OBJEXT      := o
 CFGEXT      := json
 BINEXT      := bin
 
@@ -53,15 +53,15 @@ $(EXEC): $(BUILDDIR)/$(BOOTSTRAP).$(OBJEXT) $(C_OBJECTS) $(ASM_OBJECTS)
 
 #Assemble from C sources
 $(C_OBJECTS): $(BUILDDIR)/%.$(OBJEXT) : $(BUILDDIR)/%.$(ASMEXT)
-	$(CC) -s -f IPR -o $@ $< -I$(BUILDDIR)
+	$(CC) -s -f ELF -o $@ $< -I$(BUILDDIR)
 
 #Assemble from ASM sources
 $(ASM_OBJECTS): $(BUILDDIR)/%.$(OBJEXT) : $(SRCDIR)/%.$(ASMEXT)
-	$(CC) -s -f IPR -o $@ $< -I$(BUILDDIR)
+	$(CC) -s -f ELF -o $@ $< -I$(BUILDDIR)
 
 #Assemble bootstrap
 $(BUILDDIR)/$(BOOTSTRAP).$(OBJEXT): $(BUILDDIR)/$(BOOTSTRAP).$(ASMEXT)
-	$(CC) -s -f IPR -o $@ $< -I$(BUILDDIR)
+	$(CC) -s -f ELF -o $@ $< -I$(BUILDDIR)
 
 #Compile
 $(BUILDDIR)/%.$(ASMEXT): $(SRCDIR)/%.$(SRCEXT)

--- a/checksum/dpu/build_configuration.script
+++ b/checksum/dpu/build_configuration.script
@@ -3,9 +3,9 @@
 //Create a system with 16 tasklets (0 to 15) to compute individual checksums
 //Stack_size=medium (512 bytes)
 //entry_point=task_main (for each of the 16 tasklets)
-//mailbox_size=1 (One 32-bits word per tasklet)
+//mailbox_size=2 (Two 32-bits word per tasklet)
 
-tasklet add 0..15 medium task_main 1
+tasklet add 0..15 medium task_main 2
 
 // Post the input file size into the system mailbox (One 32-bits word), accessible to any thread
 

--- a/checksum/host/Makefile
+++ b/checksum/host/Makefile
@@ -15,7 +15,8 @@ DEPEXT      := d
 OBJEXT      := o
 
 #Flags, Libraries and Includes
-CFLAGS      := -std=c11 -Wall -O3 -g -DDPU_TYPE=$(DPU_TARGET_TYPE)
+PROFILE     := $(if $(DPU_TARGET_PROFILE),-DDPU_PROFILE=$(DPU_TARGET_PROFILE))
+CFLAGS      := -std=c11 -Wall -O3 -g -DDPU_TYPE=$(DPU_TARGET_TYPE) $(PROFILE)
 LIB         := -ldpu -ldpucni -lpthread -L$(UPMEM_HOME)/usr/lib
 INC         := -I$(INCDIR) -I/usr/local/include -I$(UPMEM_HOME)/usr/share/upmem/include/host
 INCDEP      := -I$(INCDIR)


### PR DESCRIPTION
Changes the following details to be compatible with sdk-2018.1:
- no longer use '-f IPR' for intermediate build objects
- use the the DPU cycle counter instead of the removed 'dpu_time'
function and return the cycle count along with the checksum.
- update the host API (e.g. use dpu_rank_t)
- handle profile parameters from the build command-line.
 e.g. make DPU_TARGET_PROFILE=enableDbgLib=true