### PR TITLE
Use LLVM natively

### DIFF
--- a/checksum/dpu/Makefile
+++ b/checksum/dpu/Makefile
@@ -31,7 +31,7 @@ ASM_SOURCES := $(shell find $(SRCDIR) -type f -name *.$(ASMEXT))
 C_OBJECTS   := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.$(OBJEXT)))
 ASM_OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(ASM_SOURCES:.$(ASMEXT)=.$(OBJEXT)))
 
-BOOTSTRAP   := bootstrap
+BOOTSTRAP   := __bootstrap
 
 EXEC        := $(TARGETDIR)/$(TARGET).$(BINEXT)
 

--- a/checksum/dpu/Makefile
+++ b/checksum/dpu/Makefile
@@ -13,7 +13,7 @@ BUILDDIR    := ../obj/dpu
 TARGETDIR   := ../bin/dpu
 SRCEXT      := c
 ASMEXT      := s
-OBJEXT      := ipr
+OBJEXT      := o
 CFGEXT      := json
 BINEXT      := bin
 
@@ -53,15 +53,15 @@ $(EXEC): $(BUILDDIR)/$(BOOTSTRAP).$(OBJEXT) $(C_OBJECTS) $(ASM_OBJECTS)
 
 #Assemble from C sources
 $(C_OBJECTS): $(BUILDDIR)/%.$(OBJEXT) : $(BUILDDIR)/%.$(ASMEXT)
-	$(CC) -s -f IPR -o $@ $< -I$(BUILDDIR)
+	$(CC) -s -f ELF -o $@ $< -I$(BUILDDIR)
 
 #Assemble from ASM sources
 $(ASM_OBJECTS): $(BUILDDIR)/%.$(OBJEXT) : $(SRCDIR)/%.$(ASMEXT)
-	$(CC) -s -f IPR -o $@ $< -I$(BUILDDIR)
+	$(CC) -s -f ELF -o $@ $< -I$(BUILDDIR)
 
 #Assemble bootstrap
 $(BUILDDIR)/$(BOOTSTRAP).$(OBJEXT): $(BUILDDIR)/$(BOOTSTRAP).$(ASMEXT)
-	$(CC) -s -f IPR -o $@ $< -I$(BUILDDIR)
+	$(CC) -s -f ELF -o $@ $< -I$(BUILDDIR)
 
 #Compile
 $(BUILDDIR)/%.$(ASMEXT): $(SRCDIR)/%.$(SRCEXT)

--- a/checksum/dpu/Makefile
+++ b/checksum/dpu/Makefile
@@ -1,7 +1,8 @@
 #Compiler and Linker
-CC          := dpucc
+CC          := clang --target=dpu-upmem-dpurte
 #Configurator
 KCONF       := dpukconfig
+DPUCC       := dpucc
 
 #The Target Binary Program
 TARGET      := dpu_app
@@ -49,27 +50,22 @@ directories:
 
 #Link
 $(EXEC): $(BUILDDIR)/$(BOOTSTRAP).$(OBJEXT) $(C_OBJECTS) $(ASM_OBJECTS)
-	$(CC) -l -o $@ $^ $(LIB) $(DBG)
-
-#Assemble from C sources
-$(C_OBJECTS): $(BUILDDIR)/%.$(OBJEXT) : $(BUILDDIR)/%.$(ASMEXT)
-	$(CC) -s -f ELF -o $@ $< -I$(BUILDDIR)
-
-#Assemble from ASM sources
-$(ASM_OBJECTS): $(BUILDDIR)/%.$(OBJEXT) : $(SRCDIR)/%.$(ASMEXT)
-	$(CC) -s -f ELF -o $@ $< -I$(BUILDDIR)
+	$(CC) -o $@ $^ $(LIB) $(DBG)
 
 #Assemble bootstrap
 $(BUILDDIR)/$(BOOTSTRAP).$(OBJEXT): $(BUILDDIR)/$(BOOTSTRAP).$(ASMEXT)
-	$(CC) -s -f ELF -o $@ $< -I$(BUILDDIR)
+	$(CC) -c -o $@ $(CFLAGS) $^ $(INC)
 
 #Compile
-$(BUILDDIR)/%.$(ASMEXT): $(SRCDIR)/%.$(SRCEXT)
+$(ASM_OBJECTS): $(BUILDDIR)/%.$(OBJEXT) : $(SRCDIR)/%.$(ASMEXT)
+	$(CC) -c -o $@ $(CFLAGS) $^ $(INC)
+
+$(C_OBJECTS): $(BUILDDIR)/%.$(OBJEXT) : $(SRCDIR)/%.$(SRCEXT)
 	$(CC) -c -o $@ $(CFLAGS) $^ $(INC)
 
 #Generate Bootstrap
 $(BUILDDIR)/$(BOOTSTRAP).$(ASMEXT): $(BUILDDIR)/$(CFG_NAME).$(CFGEXT)
-	$(CC) -xc $^ -o $(BUILDDIR)
+	$(DPUCC) -xc $^ -o $(BUILDDIR)
 
 #Build configuration
 $(BUILDDIR)/$(CFG_NAME).$(CFGEXT): $(CFG_SCRIPT)

--- a/checksum/dpu/build_configuration.script
+++ b/checksum/dpu/build_configuration.script
@@ -3,9 +3,9 @@
 //Create a system with 16 tasklets (0 to 15) to compute individual checksums
 //Stack_size=medium (512 bytes)
 //entry_point=task_main (for each of the 16 tasklets)
-//mailbox_size=1 (One 32-bits word per tasklet)
+//mailbox_size=2 (Two 32-bits word per tasklet)
 
-tasklet add 0..15 medium task_main 1
+tasklet add 0..15 medium task_main 2
 
 // Post the input file size into the system mailbox (One 32-bits word), accessible to any thread
 

--- a/checksum/host/Makefile
+++ b/checksum/host/Makefile
@@ -15,7 +15,8 @@ DEPEXT      := d
 OBJEXT      := o
 
 #Flags, Libraries and Includes
-CFLAGS      := -std=c11 -Wall -O3 -g -DDPU_TYPE=$(DPU_TARGET_TYPE)
+PROFILE     := $(if $(DPU_TARGET_PROFILE),-DDPU_PROFILE=$(DPU_TARGET_PROFILE))
+CFLAGS      := -std=c11 -Wall -O3 -g -DDPU_TYPE=$(DPU_TARGET_TYPE) $(PROFILE)
 LIB         := -ldpu -ldpucni -lpthread -L$(UPMEM_HOME)/usr/lib
 INC         := -I$(INCDIR) -I/usr/local/include -I$(UPMEM_HOME)/usr/share/upmem/include/host
 INCDEP      := -I$(INCDIR)

--- a/checksum/host/src/app.c
+++ b/checksum/host/src/app.c
@@ -147,9 +147,9 @@ int main(int argc, char **argv) {
         if (strcmp(dpu_type_string, "fsim") == 0) {
             dpu_type = FUNCTIONAL_SIMULATOR;
         } else if (strcmp(dpu_type_string, "asic") == 0) {
-            dpu_type = ASIC;
+            dpu_type = HW;
         } else if (strcmp(dpu_type_string, "fpga") == 0) {
-            dpu_type = FPGA;
+            dpu_type = HW;
         }
     }
 


### PR DESCRIPTION
Update the toolchain invocation during the DPU build to use the shiny new LLVM tools directly rather than the dpucc wrapper